### PR TITLE
Ansible Networking Sandbox Provisioning Patch

### DIFF
--- a/provisioning/networking-hosts.yml
+++ b/provisioning/networking-hosts.yml
@@ -1,6 +1,7 @@
 - name: Sandbox networking for netplan hosts
   hosts: ssh_nodes:!routers:!windows_hosts
   become: true
+
   tasks:
     - name: Skip for non-netplan hosts
       ansible.builtin.meta: end_host
@@ -9,7 +10,23 @@
     - name: Get user network interface
       set_fact:
         user_network_interface: "{{ ansible_interfaces | map('regex_replace', '^', 'ansible_') | map('extract', vars) | selectattr('ipv4.address', 'defined') | selectattr('ipv4.address', 'eq', user_network_ip) | map(attribute='device') | first }}"
-
+        management_interface: >-
+          {{
+            ansible_interfaces
+            | map('regex_replace', '^', 'ansible_')
+            | map('extract', vars)
+            | selectattr('ipv4.address', 'defined')
+            | selectattr('ipv4.address', 'equalto', ansible_host)
+            | map(attribute='device')
+            | first
+            | default('')
+          }}
+          
+    - name: Check management interface
+      fail:
+        msg: "backend-sandbox-service: cannot determine management interface"
+      when: management_interface == ''
+          
     - name: Create Netplan configuration file
       copy:
         content: |
@@ -17,23 +34,29 @@
           network:
             version: 2
             ethernets:
-              {% for interface in ansible_interfaces | reject('equalto', 'lo') | sort %}
-              {{ interface }}:
+              {% set interfaces_sorted = ansible_interfaces | reject('equalto', 'lo') | sort %}
+              {% set ns = namespace(metric=200) %}
+    
+              {% for iface in interfaces_sorted %}
+              {{ iface }}:
                 dhcp4: true
                 dhcp4-overrides:
-                  route-metric: {{ 100 if interface == user_network_interface else 200 }}
+                  route-metric: {{ 100 if iface == management_interface else ns.metric }}
                 dhcp6: false
+              {% if iface != management_interface %}
+              {% set ns.metric = ns.metric + 100 %}
+              {% endif %}
               {% endfor %}
         dest: /etc/netplan/50-cloud-init.yaml
         owner: root
         group: root
         mode: '0600'
       register: netplan_config
-
+     
     - name: Apply Netplan
       command: netplan apply
       when: netplan_config is changed
-
+          
 - name: Test sandbox networking
   hosts: ssh_nodes:!routers:!windows_hosts
   tasks:
@@ -63,6 +86,49 @@
 
   - name: Gather facts
     setup:
+
+  - name: Configure Windows interface metrics
+    win_shell: |
+      $ManagementIP = "{{ ansible_host }}"
+      $UserIP = "{{ user_network_ip }}"
+  
+      $ManagementIfIndex = (
+        Get-NetIPAddress -AddressFamily IPv4 |
+        Where-Object IPAddress -eq $ManagementIP |
+        Select-Object -First 1
+      ).InterfaceIndex
+  
+      if (-not $ManagementIfIndex) {
+        throw "Cannot determine management interface for IP $ManagementIP"
+      }
+  
+      # Only sandbox-related interfaces (management + user network)
+      $SandboxIfIndexes = (
+        Get-NetIPAddress -AddressFamily IPv4 |
+        Where-Object {
+          $_.IPAddress -eq $ManagementIP -or
+          $_.IPAddress -eq $UserIP
+        } |
+        Select-Object -ExpandProperty InterfaceIndex -Unique
+      )
+  
+      foreach ($IfIndex in $SandboxIfIndexes) {
+  
+        $DesiredMetric = if ($IfIndex -eq $ManagementIfIndex) { 100 } else { 200 }
+  
+        $Current = Get-NetIPInterface -InterfaceIndex $IfIndex -AddressFamily IPv4
+  
+        if (
+          $Current.InterfaceMetric -ne $DesiredMetric -or
+          $Current.AutomaticMetric -eq "Enabled"
+        ) {
+          Set-NetIPInterface `
+            -InterfaceIndex $IfIndex `
+            -AddressFamily IPv4 `
+            -AutomaticMetric Disabled `
+            -InterfaceMetric $DesiredMetric
+        }
+      }
 
   - name: test sandbox networking
     win_command: 'ping {{ hostvars["man"]["default_gateway_interface_ip"] }}'

--- a/provisioning/networking-routers.yml
+++ b/provisioning/networking-routers.yml
@@ -35,23 +35,35 @@
       msg: "Network unavailable, using existing package cache"
     when: network_test is failed
 
+
 - name: Sandbox networking
   hosts: man:routers
   become: true
+  gather_facts: false
   strategy: host_pinned
   pre_tasks:
+  
+  - name: Ensure all interfaces have IP address assigned
+    ansible.builtin.setup:
+    failed_when: "ansible_interfaces | map('regex_replace', '^', 'ansible_') | map('extract', vars) | rejectattr('ipv4', 'defined') | rejectattr('ipv6', 'defined') | length > 0"
+    retries: 40
+    delay: 5
+
+  - name: Gather facts after network stabilization
+    ansible.builtin.setup:
+    
   - name: Get systemd-resolved status (using command)
     command: resolvectl status
     register: resolved_status
     changed_when: false
     check_mode: false
     failed_when: false
-
+  
   - name: Extract DNS Servers (using regex - handles global and per-link)
     set_fact:
       resolved_upstream_dns: "{{ resolved_status.stdout | regex_findall('DNS Servers: (.*)') | map('trim') | join(' ') | split() }}"
     when: resolved_status.rc == 0
-
+ 
   roles:
   - role: interface
     interface_mtu: "{{ hostvars['proxy-jump']['ansible_default_ipv4']['mtu'] }}"


### PR DESCRIPTION
1. Prevent provisioning failures caused by network race conditions. Ensure networking is fully initialized before provisioning continues. Without this stabilization step, provisioning may fail because interfaces are not ready or IP addresses are not assigned yet. Replace systemd-networkd specific checks with a generic interface IP assignment validation using Ansible facts, following vydra-cshub's suggestion. This removes the dependency on systemd-based networking and improves compatibility across a wider range of OS.

2. Enforce deterministic default routing by explicitly setting DHCP route metrics: the management interface is always prioritized (metric 100), while all other interfaces are assigned incrementally increasing metrics based on sorted order, ensuring stable and predictable route selection and failover behavior in multi-homed sandbox environments.